### PR TITLE
fix: using custom request init

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -34,6 +34,7 @@ import {
   RequestPolicy,
   PromisifiedSource,
   DebugEvent,
+  CustomRequestInit,
 } from './types';
 
 import {
@@ -51,7 +52,7 @@ export interface ClientOptions {
   /** Target endpoint URL such as `https://my-target:8080/graphql`. */
   url: string;
   /** Any additional options to pass to fetch. */
-  fetchOptions?: RequestInit | (() => RequestInit);
+  fetchOptions?: CustomRequestInit | (() => CustomRequestInit);
   /** An alternative fetch implementation. */
   fetch?: typeof fetch;
   /** An ordered array of Exchanges. */
@@ -83,7 +84,7 @@ export class Client {
   // These are variables derived from ClientOptions
   url: string;
   fetch?: typeof fetch;
-  fetchOptions?: RequestInit | (() => RequestInit);
+  fetchOptions?: CustomRequestInit | (() => CustomRequestInit);
   suspense: boolean;
   preferGetMethod: boolean;
   requestPolicy: RequestPolicy;

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -1,7 +1,7 @@
 import { Kind, print, DocumentNode } from 'graphql';
 
 import { stringifyVariables } from '../utils';
-import { Operation } from '../types';
+import { Operation, CustomRequestInit } from '../types';
 
 export interface FetchBody {
   query?: string;
@@ -81,7 +81,7 @@ export const makeFetchOptions = (
   const extraOptions =
     typeof operation.context.fetchOptions === 'function'
       ? operation.context.fetchOptions()
-      : operation.context.fetchOptions || {};
+      : operation.context.fetchOptions || ({} as CustomRequestInit);
 
   return {
     ...extraOptions,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export interface OperationContext {
   [key: string]: any;
   additionalTypenames?: string[];
   fetch?: typeof fetch;
-  fetchOptions?: RequestInit | (() => RequestInit);
+  fetchOptions?: CustomRequestInit | (() => CustomRequestInit);
   requestPolicy: RequestPolicy;
   url: string;
   pollInterval?: number;
@@ -130,3 +130,9 @@ export type DebugEvent<
   timestamp: number;
   source: string;
 };
+
+type RequestInitWithoutHeader = Omit<RequestInit, 'headers'>;
+type CustomHeadersInit = Exclude<HeadersInit, Headers>;
+export interface CustomRequestInit extends RequestInitWithoutHeader {
+  headers?: CustomHeadersInit;
+}


### PR DESCRIPTION
## Summary

<!-- What's the motivation of this change? What does it solve? -->
Updates `RequestInit` in `fetch` to not allow `Headers` object in `headers` property. I tried using `Headers` object, but because we just spread the object, it would fail.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
This affects the `core` package.
This is a breaking change.
